### PR TITLE
Updating extraction in spiders

### DIFF
--- a/antara/antara/spiders/antara_spider.py
+++ b/antara/antara/spiders/antara_spider.py
@@ -22,9 +22,9 @@ class AntaraSpider(scrapy.Spider):
 
         for indek in indeks:
             item = AntaraItem()
-            item['title'] = indek.xpath('div/div[@class="bxpd"]/h3/a/text()').extract()[0]
-            item['link'] = "http://www.antaranews.com" + indek.xpath('div/div[@class="bxpd"]/h3/a/@href').extract()[0]
-            item['images'] = indek.xpath('div/div[@class="imgpg"]/a/img/@src').extract()[0]
+            item['title'] = indek.xpath('div/div[@class="bxpd"]/h3/a/text()').extract_first()
+            item['link'] = response.urljoin(indek.xpath('div/div[@class="bxpd"]/h3/a/@href').extract_first())
+            item['images'] = indek.xpath('div/div[@class="imgpg"]/a/img/@src').extract_first()
             item['category'] = ""
             item['date'] = time.strftime("%d/%m/%Y")
             item['desc'] = ""

--- a/kompas/kompas/spiders/kompas_spider.py
+++ b/kompas/kompas/spiders/kompas_spider.py
@@ -21,11 +21,11 @@ class KompasSpider(scrapy.Spider):
 
         for indek in indeks:
             item = KompasItem()
-            item['title'] = indek.xpath('div[@class="article__list__title"]/h3/a/text()').extract()[0]
-            item['link'] = indek.xpath('div[@class="article__list__title"]/h3/a/@href').extract()[0]
-            item['images'] = indek.xpath('div[@class="article__list__asset clearfix"]/div/img/@src').extract()[0]
-            item['category'] = indek.xpath('div[@class="article__list__info"]/div[@class="article__subtitle article__subtitle--inline"]/text()').extract()[0]
-            item['date'] = indek.xpath('div[@class="article__list__info"]/div[@class="article__date"]/text()').extract()[0]
+            item['title'] = indek.xpath('div[@class="article__list__title"]/h3/a/text()').extract_first()
+            item['link'] = indek.xpath('div[@class="article__list__title"]/h3/a/@href').extract_first()
+            item['images'] = indek.xpath('div[@class="article__list__asset clearfix"]/div/img/@src').extract_first()
+            item['category'] = indek.xpath('div[@class="article__list__info"]/div[@class="article__subtitle article__subtitle--inline"]/text()').extract_first()
+            item['date'] = indek.xpath('div[@class="article__list__info"]/div[@class="article__date"]/text()').extract_first()
             item['desc'] = ""
 
             yield item

--- a/liputan6/liputan6/spiders/liputan6_spider.py
+++ b/liputan6/liputan6/spiders/liputan6_spider.py
@@ -21,11 +21,11 @@ class RepublikaSpider(scrapy.Spider):
 
         for indek in indeks:
             item = Liputan6Item()
-            item['title'] = indek.xpath('aside/header/h4/a/@title').extract()[0].strip()
-            item['link'] = indek.xpath('aside/header/h4/a/@href').extract()[0].strip()
+            item['title'] = indek.xpath('aside/header/h4/a/@title').extract_first().strip()
+            item['link'] = indek.xpath('aside/header/h4/a/@href').extract_first().strip()
             item['images'] = ""
-            item['category'] = indek.xpath('aside/header/a/text()').extract()[0].strip()
-            item['date'] = indek.xpath('aside/header/span/time/@datetime').extract()[0].strip()
-            item['desc'] = indek.xpath('aside/div/text()').extract()[0].strip()
+            item['category'] = indek.xpath('aside/header/a/text()').extract_first().strip()
+            item['date'] = indek.xpath('aside/header/span/time/@datetime').extract_first().strip()
+            item['desc'] = indek.xpath('aside/div/text()').extract_first().strip()
 
             yield item

--- a/merdeka/merdeka/spiders/merdeka_spider.py
+++ b/merdeka/merdeka/spiders/merdeka_spider.py
@@ -22,10 +22,10 @@ class TirtoSpider(scrapy.Spider):
 
         for indek in indeks:
             item = MerdekaItem()
-            item['title'] = indek.xpath('div[@class="mdk-tag-contln-r2"]/div[@class="mdk-tag-contln-titlebar"]/a/text()').extract()[0]
-            item['link'] = "https://www.merdeka.com" + indek.xpath('div[@class="mdk-tag-contln-r2"]/div[@class="mdk-tag-contln-titlebar"]/a/@href').extract()[0]
-            item['images'] = indek.xpath('div[@class="mdk-tag-contln-l"]/a/img/@src').extract()[0]
-            item['category'] = indek.xpath('div[@class="mdk-tag-contln-r2"]/div[@class="mdk-tag-contln-date"]/span/text()').extract()[0]
+            item['title'] = indek.xpath('div[@class="mdk-tag-contln-r2"]/div[@class="mdk-tag-contln-titlebar"]/a/text()').extract_first()
+            item['link'] = response.urljoin(indek.xpath('div[@class="mdk-tag-contln-r2"]/div[@class="mdk-tag-contln-titlebar"]/a/@href').extract_first())
+            item['images'] = indek.xpath('div[@class="mdk-tag-contln-l"]/a/img/@src').extract_first()
+            item['category'] = indek.xpath('div[@class="mdk-tag-contln-r2"]/div[@class="mdk-tag-contln-date"]/span/text()').extract_first()
             item['date'] = time.strftime("%d/%m/%Y")
             item['desc'] = ""
 

--- a/okezone/okezone/spiders/okezone_spider.py
+++ b/okezone/okezone/spiders/okezone_spider.py
@@ -1,6 +1,7 @@
 import scrapy
 import time
 import sys
+from __future__ import print_function
 from bs4 import BeautifulSoup
 from scrapy.selector import Selector
 from scrapy.http.request import Request
@@ -35,7 +36,7 @@ class OkezoneSpider(scrapy.Spider):
             yield detail_request
 
     def parse_detail(self, response):
-        print "Crawling detail news"
+        print("Crawling detail news")
         item = response.meta['item']
         selector = Selector(response)
         description = selector.xpath('//*[@id="contentx"]').extract_first()

--- a/republika/republika/spiders/republika_spider.py
+++ b/republika/republika/spiders/republika_spider.py
@@ -18,7 +18,7 @@ class RepublikaSpider(scrapy.Spider):
         @url http://www.republika.co.id/indeks
         @returns items
         """
-        print "Crawling list of news"
+        print("Crawling list of news")
         indeks = Selector(response).xpath('//div[@class="wp-indeks"]')
         indeks_length = len(indeks)
         if float(indeks_length) > 0:
@@ -51,7 +51,7 @@ class RepublikaSpider(scrapy.Spider):
             )
 
     def parse_detail(self, response):
-        print "Crawling detail news"
+        print("Crawling detail news")
         item = response.meta['item']
         selector = Selector(response)
         description = selector.xpath('//div[@class="content-detail"]').extract_first()

--- a/tempo/tempo/spiders/tempo_spider.py
+++ b/tempo/tempo/spiders/tempo_spider.py
@@ -34,7 +34,7 @@ class VivaSpider(scrapy.Spider):
             yield detail_request
     
     def parse_detail(self, response):
-        print "Crawling detail news"
+        print("Crawling detail news")
         item = response.meta['item']
         selector = Selector(response)
         description = selector.xpath('//article').extract_first()

--- a/tirto/tirto/spiders/tirto_spider.py
+++ b/tirto/tirto/spiders/tirto_spider.py
@@ -37,7 +37,7 @@ class TirtoSpider(scrapy.Spider):
             yield detail_request
 
     def parse_detail(self, response):
-        print "Crawling detail news"
+        print("Crawling detail news")
         item = response.meta['item']
         selector = Selector(response)
         description = selector.xpath('//div[@class="content-text-editor"]').extract_first()

--- a/viva/viva/spiders/viva_spider.py
+++ b/viva/viva/spiders/viva_spider.py
@@ -23,18 +23,18 @@ class VivaSpider(scrapy.Spider):
 
         for indek in indeks:
             item = VivaItem()
-            news_link = indek.xpath('div[@class="content_center"]/span/a[2]/@href').extract()[0]
-            item['title'] = indek.xpath('div[@class="content_center"]/span/a[2]/h3/text()').extract()[0]
+            news_link = indek.xpath('div[@class="content_center"]/span/a[2]/@href').extract_first()
+            item['title'] = indek.xpath('div[@class="content_center"]/span/a[2]/h3/text()').extract_first()
             item['link'] = news_link
-            item['images'] = indek.xpath('div[@class="thumb"]/a/img/@data-original').extract()[0]
-            item['category'] = indek.xpath('div[@class="content_center"]/span/a[1]/h5/text()').extract()[0].strip()
-            item['date'] = indek.xpath('div[@class="content_center"]/span/div[@class="date"]/text()').extract()[0]
+            item['images'] = indek.xpath('div[@class="thumb"]/a/img/@data-original').extract_first()
+            item['category'] = indek.xpath('div[@class="content_center"]/span/a[1]/h5/text()').extract_first().strip()
+            item['date'] = indek.xpath('div[@class="content_center"]/span/div[@class="date"]/text()').extract_first()
             detail_request = Request(news_link, callback=self.parse_detail)
             detail_request.meta['item'] = item
             yield detail_request
 
     def parse_detail(self, response):
-        print "Crawling detail news"
+        print("Crawling detail news")
         item = response.meta['item']
         selector = Selector(response)
         description = selector.xpath('//div[@id="article-detail-content"]').extract_first()


### PR DESCRIPTION
Hi.  I'm submitting this pull request to fix #20 and a few other things.

1.  I've fixed #20. You were using `.extract()[0]` in some of your spiders instead of `.extract_first()`. `extract_first()` does the same thing, but will appropriately return `None` if nothing is extracted. I no longer get the `IndexError`.
2.  I've uses `reposnse.urljoin(<path>)` instead of string concatenation. This will fail more gracefully and works better overall.
3. I used the more general print function (`from __future__ import print_function`) so that this works for Python 2 and 3. This was the only thing preventing it being 2 and 3 compatible and it's an easy fix.

I tested things and everything worked as expected in Python 2 and 3.  Let me know if you have any questions or concerns!